### PR TITLE
Align taint checking with new func signatures

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -69,7 +69,9 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRestArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTableQueryExpression;
@@ -813,6 +815,14 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
     @Override
     public void visit(BLangTableQueryExpression tableQueryExpression) {
         /* ignore */
+    }
+
+    public void visit(BLangRestArgsExpression varArgsExpression) {
+        varArgsExpression.expr.accept(this);
+    }
+
+    public void visit(BLangNamedArgsExpression namedArgsExpression) {
+        namedArgsExpression.expr.accept(this);
     }
 
     // Private

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -28,6 +28,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.TaintRecord;
@@ -116,13 +117,16 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.xml.XMLConstants;
 
 /**
@@ -156,7 +160,7 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
     private BlockedNode blockedNode;
     private List<Boolean> taintedStatusList;
     private List<Boolean> returnTaintedStatusList;
-    private List<TaintRecord.TaintError> taintErrorList = new ArrayList<>();
+    private Set<TaintRecord.TaintError> taintErrorSet = new LinkedHashSet<>();
     private Map<BlockingNode, List<BlockedNode>> blockedNodeMap = new HashMap<>();
 
     private static final String ANNOTATION_TAINTED = "tainted";
@@ -904,16 +908,20 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
 
     private void visitEntryPoint(BLangInvokableNode invNode, SymbolEnv funcEnv) {
         // Entry point input parameters are all tainted, since they contain user controlled data.
-        if (invNode.params != null) {
-            invNode.params.forEach(param -> {
-                param.symbol.tainted = true;
-                if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
-                    this.dlog.error(param.pos, DiagnosticCode.ENTRY_POINT_PARAMETERS_CANNOT_BE_SENSITIVE,
-                            param.name.value);
-                    return;
-                }
-            });
+        // If any value has been marked "sensitive" generate an error.
+        if (!isEntryPointParamsValid(invNode.requiredParams)) {
+            return;
         }
+        List<BLangVariable> defaultableParamsVarList = new ArrayList<>();
+        invNode.defaultableParams.forEach(defaultableParam -> defaultableParamsVarList.add(defaultableParam.var));
+        if (!isEntryPointParamsValid(defaultableParamsVarList)) {
+            return;
+        }
+        if (invNode.restParam != null
+                && !isEntryPointParamsValid(Arrays.asList(new BLangVariable[] {invNode.restParam}))) {
+            return;
+        }
+        // Perform end point analysis.
         entryPointAnalysis = true;
         analyzeReturnTaintedStatus(invNode, funcEnv);
         entryPointAnalysis = false;
@@ -922,13 +930,26 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
             return;
         } else {
             // Display errors only if scan of was fully complete, so that errors will not get duplicated.
-            taintErrorList.forEach(error -> {
+            taintErrorSet.forEach(error -> {
                 this.dlog.error(error.pos, error.diagnosticCode, error.paramName);
             });
-            taintErrorList.clear();
+            taintErrorSet.clear();
         }
-        invNode.params.forEach(param -> param.symbol.tainted = false);
         invNode.symbol.taintTable = new HashMap<>();
+    }
+
+    private boolean isEntryPointParamsValid(List<BLangVariable> params) {
+        if (params != null) {
+            for (BLangVariable param : params) {
+                param.symbol.tainted = true;
+                if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
+                    this.dlog.error(param.pos, DiagnosticCode.ENTRY_POINT_PARAMETERS_CANNOT_BE_SENSITIVE,
+                            param.name.value);
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private void visitInvokable(BLangInvokableNode invNode, SymbolEnv symbolEnv) {
@@ -940,42 +961,59 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
             Map<Integer, TaintRecord> taintTable = new HashMap<>();
             returnTaintedStatusList = null;
             // Check the tainted status of return values when no parameter is tainted.
-            analyzeReturnTaintedStatus(taintTable, invNode, symbolEnv, ALL_UNTAINTED_TABLE_ENTRY_INDEX);
+            analyzeAllParamsUntaintedReturnTaintedStatus(taintTable, invNode, symbolEnv);
             boolean isBlocked = processBlockedNode(invNode);
             if (isBlocked) {
                 return;
             }
-            List<BLangVariable> params = invNode.params;
-            for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
-                BLangVariable param = params.get(paramIndex);
+            int requiredParamCount = invNode.requiredParams.size();
+            int defaultableParamCount = invNode.defaultableParams.size();
+            int totalParamCount = requiredParamCount + defaultableParamCount + (invNode.restParam == null ? 0 : 1);
+            for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
+                BLangVariable param = getParam(invNode, paramIndex, requiredParamCount, defaultableParamCount);
                 // If parameter is sensitive, it is invalid to have a case where tainted status of parameter is true.
                 if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
                     continue;
                 }
                 returnTaintedStatusList = null;
                 // Set each parameter "tainted", then analyze the body to observe the outcome of the function.
-                analyzeReturnTaintedStatus(taintTable, invNode, symbolEnv, paramIndex);
+                analyzeReturnTaintedStatus(taintTable, invNode, symbolEnv, paramIndex, requiredParamCount,
+                        defaultableParamCount);
             }
-            invNode.params.forEach(param -> param.symbol.tainted = false);
             invNode.symbol.taintTable = taintTable;
         }
     }
 
+    private void analyzeAllParamsUntaintedReturnTaintedStatus(Map<Integer, TaintRecord> taintTable,
+                                                                  BLangInvokableNode invokableNode,
+                                                                  SymbolEnv symbolEnv) {
+        analyzeReturnTaintedStatus(taintTable, invokableNode, symbolEnv, ALL_UNTAINTED_TABLE_ENTRY_INDEX, 0, 0);
+    }
+
     private void analyzeReturnTaintedStatus(Map<Integer, TaintRecord> taintTable, BLangInvokableNode invokableNode,
-                                            SymbolEnv symbolEnv, int paramIndex) {
-        if (invokableNode.params != null) {
-            invokableNode.params.forEach(param -> param.symbol.tainted = false);
+                                            SymbolEnv symbolEnv, int paramIndex, int requiredParamCount,
+                                            int defaultableParamCount) {
+        resetTaintedStatusOfVariables(invokableNode.requiredParams);
+        resetTaintedStatusOfVariableDef(invokableNode.defaultableParams);
+        if (invokableNode.restParam != null) {
+            resetTaintedStatusOfVariables(Arrays.asList(new BLangVariable[]{invokableNode.restParam}));
         }
         // Mark the given parameter "tainted".
         if (paramIndex != ALL_UNTAINTED_TABLE_ENTRY_INDEX) {
-            invokableNode.params.get(paramIndex).symbol.tainted = true;
+            if (paramIndex < requiredParamCount) {
+                invokableNode.requiredParams.get(paramIndex).symbol.tainted = true;
+            } else if (paramIndex < requiredParamCount + defaultableParamCount) {
+                invokableNode.defaultableParams.get(paramIndex - requiredParamCount).var.symbol.tainted = true;
+            } else {
+                invokableNode.restParam.symbol.tainted = true;
+            }
         }
         analyzeReturnTaintedStatus(invokableNode, symbolEnv);
-        if (taintErrorList.size() > 0) {
+        if (taintErrorSet.size() > 0) {
             // When invocation returns an error (due to passing a tainted argument to a sensitive parameter) add current
             // error to the table for future reference.
-            taintTable.put(paramIndex, new TaintRecord(null, new ArrayList<>(taintErrorList)));
-            taintErrorList.clear();
+            taintTable.put(paramIndex, new TaintRecord(null, new ArrayList<>(taintErrorSet)));
+            taintErrorSet.clear();
         } else if (this.blockedNode == null) {
             if (invokableNode.retParams.size() == 0) {
                 returnTaintedStatusList = new ArrayList<>();
@@ -986,13 +1024,27 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
         }
     }
 
+    private void resetTaintedStatusOfVariables(List<BLangVariable> params) {
+        if (params != null) {
+            params.forEach(param -> param.symbol.tainted = false);
+        }
+    }
+
+    private void resetTaintedStatusOfVariableDef(List<BLangVariableDef> params) {
+        if (params != null) {
+            List<BLangVariable> defaultableParamsVarList = new ArrayList<>();
+            params.forEach(defaultableParam -> defaultableParamsVarList.add(defaultableParam.var));
+            resetTaintedStatusOfVariables(defaultableParamsVarList);
+        }
+    }
+
     private void analyzeReturnTaintedStatus(BLangInvokableNode invokableNode, SymbolEnv symbolEnv) {
         if (invokableNode.workers.isEmpty()) {
             analyzeNode(invokableNode.body, symbolEnv);
         } else {
             for (BLangWorker worker : invokableNode.workers) {
                 analyzeNode(worker, symbolEnv);
-                if (this.blockedNode != null || taintErrorList.size() > 0) {
+                if (this.blockedNode != null || taintErrorSet.size() > 0) {
                     break;
                 }
             }
@@ -1009,11 +1061,15 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
             // Append taint table with tainted status when no parameter is tainted.
             Map<Integer, TaintRecord> taintTable = new HashMap<>();
             taintTable.put(ALL_UNTAINTED_TABLE_ENTRY_INDEX, new TaintRecord(retParamsTaintedStatus, null));
-            if (invokableNode.params.size() > 0) {
+            int requiredParamCount = invokableNode.requiredParams.size();
+            int defaultableParamCount = invokableNode.defaultableParams.size();
+            int totalParamCount = requiredParamCount + defaultableParamCount +
+                    (invokableNode.restParam == null ? 0 : 1);
+            if (totalParamCount > 0) {
                 // Append taint table with tainted status when each parameter is tainted.
-                List<BLangVariable> params = invokableNode.params;
-                for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
-                    BLangVariable param = params.get(paramIndex);
+                for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
+                    BLangVariable param = getParam(invokableNode, paramIndex, requiredParamCount,
+                            defaultableParamCount);
                     // If parameter is sensitive, test for this parameter being tainted is invalid.
                     if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
                         continue;
@@ -1063,7 +1119,7 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
             this.blockedNode = null;
             // Discard any error generated if invokable was found to be blocked. This will avoid duplicates when
             // blocked invokable is re-examined.
-            taintErrorList.clear();
+            taintErrorSet.clear();
             isBlocked = true;
         }
         return isBlocked;
@@ -1074,11 +1130,17 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
         if (function.symbol.taintTable == null) {
             addToBlockedList(invocationExpr);
         } else {
+            int requiredParamCount = function.requiredParams.size();
+            int defaultableParamCount = function.defaultableParams.size();
+            int totalParamCount = requiredParamCount + defaultableParamCount +
+                    (function.restParam == null ? 0 : 1);
             Map<Integer, TaintRecord> taintTable = function.symbol.taintTable;
-            for (int paramIndex = 0; paramIndex < function.params.size(); paramIndex++) {
+            for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
                 TaintRecord taintRecord = taintTable.get(paramIndex);
+                BLangVariable param = getParam(function, paramIndex, requiredParamCount,
+                        defaultableParamCount);
                 if (taintRecord == null) {
-                    addTaintError(argExpr.pos, function.params.get(paramIndex).name.value,
+                    addTaintError(argExpr.pos, param.name.value,
                             DiagnosticCode.TAINTED_VALUE_PASSED_TO_SENSITIVE_PARAMETER);
                 } else if (taintRecord.taintError != null && taintRecord.taintError.size() > 0) {
                     addTaintError(taintRecord.taintError);
@@ -1092,14 +1154,14 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
 
     private void addTaintError(DiagnosticPos diagnosticPos, String paramName, DiagnosticCode diagnosticCode) {
         TaintRecord.TaintError taintError = new TaintRecord.TaintError(diagnosticPos, paramName, diagnosticCode);
-        taintErrorList.add(taintError);
+        taintErrorSet.add(taintError);
         if (!entryPointAnalysis) {
             stopAnalysis = true;
         }
     }
 
     private void addTaintError(List<TaintRecord.TaintError> taintError) {
-        taintErrorList.addAll(taintError);
+        taintErrorSet.addAll(taintError);
         if (!entryPointAnalysis) {
             stopAnalysis = true;
         }
@@ -1138,7 +1200,13 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
                     if (taintRecord == null) {
                         // This is when current parameter is "sensitive". Therefore, providing a tainted
                         // value to a sensitive parameter is invalid and should return a compiler error.
-                        addTaintError(argExpr.pos, invokableSymbol.params.get(argIndex).name.value,
+                        int requiredParamCount = invokableSymbol.params.size();
+                        int defaultableParamCount = invokableSymbol.defaultableParams.size();
+                        int totalParamCount = requiredParamCount + defaultableParamCount +
+                                (invokableSymbol.restParam == null ? 0 : 1);
+                        BVarSymbol paramSymbol = getParamSymbol(invokableSymbol, argIndex, requiredParamCount,
+                                defaultableParamCount);
+                        addTaintError(argExpr.pos, paramSymbol.name.value,
                                 DiagnosticCode.TAINTED_VALUE_PASSED_TO_SENSITIVE_PARAMETER);
                     } else if (taintRecord.taintError != null && taintRecord.taintError.size() > 0) {
                         // This is when current parameter is derived to be sensitive. The error already generated
@@ -1161,12 +1229,14 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
         }
         if (invocationExpr.expr != null) {
             // When an invocation like stringValue.trim() happens, if stringValue is tainted, the result will
-            // also be tainted, unless it was explicitly marked untainted using @untainted with returns.
+            // also be tainted.
+            //TODO: TaintedIf annotation, so that it's possible to define what can taint or untaint the return.
             invocationExpr.expr.accept(this);
             for (int i = 0; i < returnTaintedStatus.size(); i++) {
-                returnTaintedStatus.set(i, getObservedTaintedStatus());
+                if (getObservedTaintedStatus()) {
+                    returnTaintedStatus.set(i, getObservedTaintedStatus());
+                }
             }
-            //TODO: TaintedIf annotation, so that it's possible to define what can taint or untaint the return.
         }
         taintedStatusList = returnTaintedStatus;
     }
@@ -1241,6 +1311,32 @@ public class TaintAnalyzer  extends BLangNodeVisitor {
             }
         }
         return false;
+    }
+
+    private BLangVariable getParam(BLangInvokableNode invNode, int paramIndex, int requiredParamCount,
+                                   int defaultableParamCount) {
+        BLangVariable param;
+        if (paramIndex < requiredParamCount) {
+            param = invNode.requiredParams.get(paramIndex);
+        } else if (paramIndex < requiredParamCount + defaultableParamCount) {
+            param = invNode.defaultableParams.get(paramIndex - requiredParamCount).var;
+        } else {
+            param = invNode.restParam;
+        }
+        return param;
+    }
+
+    private BVarSymbol getParamSymbol(BInvokableSymbol invSymbol, int paramIndex, int requiredParamCount,
+                                      int defaultableParamCount) {
+        BVarSymbol param;
+        if (paramIndex < requiredParamCount) {
+            param = invSymbol.params.get(paramIndex);
+        } else if (paramIndex < requiredParamCount + defaultableParamCount) {
+            param = invSymbol.defaultableParams.get(paramIndex - requiredParamCount);
+        } else {
+            param = invSymbol.restParam;
+        }
+        return param;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -107,6 +107,7 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.xml.XMLConstants;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -20,10 +20,10 @@ package org.wso2.ballerinalang.compiler.semantics.analyzer;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
-import org.ballerinalang.model.tree.expressions.NamedArgNode;
-import org.ballerinalang.model.types.Type;
 import org.ballerinalang.model.tree.clauses.SelectExpressionNode;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
+import org.ballerinalang.model.tree.expressions.NamedArgNode;
+import org.ballerinalang.model.types.Type;
 import org.ballerinalang.util.diagnostic.DiagnosticCode;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types.RecordKind;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
@@ -107,7 +107,6 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.XMLConstants;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
@@ -50,5 +50,33 @@ public class TaintRecord {
             this.paramName = paramName;
             this.diagnosticCode = diagnosticCode;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TaintError that = (TaintError) o;
+
+            if (!pos.toString().equals(that.pos.toString())) {
+                return false;
+            }
+            if (!paramName.equals(that.paramName)) {
+                return false;
+            }
+            return diagnosticCode == that.diagnosticCode;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = pos.toString().hashCode();
+            result = 31 * result + paramName.hashCode();
+            result = 31 * result + diagnosticCode.hashCode();
+            return result;
+        }
     }
 }

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/taintchecking.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/taintchecking.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ballerina.builtin;
+
+public annotation sensitive attach parameter, const {
+
+}
+
+public annotation tainted attach parameter, const {
+
+}
+
+public annotation untainted attach parameter, const {
+
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
@@ -46,6 +46,35 @@ public class AnnotationTest {
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 50);
     }
 
+    @Test
+    public void testSensitiveDefaultArgs() {
+        CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-default-args.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 0);
+    }
+
+    @Test
+    public void testSensitiveDefaultArgsNegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/annotations/sensitive-default-args-negative.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 2);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 56);
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 81);
+    }
+
+    @Test
+    public void testSensitiveRestArgs() {
+        CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-rest-args.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 0);
+    }
+
+    @Test
+    public void testSensitiveRestArgsNegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/annotations/sensitive-rest-args-negative.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 2);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 30);
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 29);
+    }
     // Test @tainted annotation.
 
     @Test

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-default-args-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-default-args-negative.bal
@@ -1,0 +1,14 @@
+public function main (string[] args) {
+    secureFunctionFirstDefaultParamSensitive("static", secureIn = args[0], insecureIn2 = "static");
+    secureFunctionSecondDefaultParamSensitive("static", insecureIn2 = "static", secureIn = args[0]);
+}
+
+public function secureFunctionFirstDefaultParamSensitive (string insecureIn1,
+                                                          @sensitive{} string secureIn = "example",
+                                                          string insecureIn2 = "example") {
+}
+
+public function secureFunctionSecondDefaultParamSensitive (string insecureIn1,
+                                                           string insecureIn2 = "example",
+                                                           @sensitive{} string secureIn = "example") {
+}

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-default-args.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-default-args.bal
@@ -1,0 +1,14 @@
+public function main (string[] args) {
+    secureFunctionFirstDefaultParamSensitive("static", secureIn = "static", insecureIn2 = args[0]);
+    secureFunctionSecondDefaultParamSensitive("static", insecureIn2 = args[0], secureIn = "static");
+}
+
+public function secureFunctionFirstDefaultParamSensitive (string insecureIn1,
+                                                          @sensitive{} string secureIn = "example",
+                                                          string insecureIn2 = "example") {
+}
+
+public function secureFunctionSecondDefaultParamSensitive (string insecureIn1,
+                                                           string insecureIn2 = "example",
+                                                           @sensitive{} string secureIn = "example") {
+}

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-rest-args-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-rest-args-negative.bal
@@ -1,0 +1,7 @@
+public function main (string[] args) {
+    secureFunction("static", ...args);
+    secureFunction(args[0], ...args);
+}
+
+public function secureFunction (string insecureIn, @sensitive{} string... secureIn) {
+}

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-rest-args.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/annotations/sensitive-rest-args.bal
@@ -1,0 +1,8 @@
+public function main (string[] args) {
+    string[] arr = ["static"];
+    secureFunction("static", ...arr);
+    secureFunction(args[0], ...arr);
+}
+
+public function secureFunction (string insecureIn, @sensitive{} string... secureIn) {
+}


### PR DESCRIPTION
## Purpose
> New function signature changes breaks the parameter list into three parts. Taint checking feature should align with this change, since it's heavily reliant on the parameter index for taint-table generation. 

## Goals
> Align taint-checking, including taint table generation to matching with new function signature changes. 

## Approach
> Modify TaintAnalyzer to include combined verifications of parameters. Index is still used (and unchanged) to generate the taint-table, to make sure there is no impact on the taint-table that will get added to Balo files. 